### PR TITLE
Fix access none in AutoRecorder.NotifyLevelChange

### DIFF
--- a/Classes/AutoRecorder.uc
+++ b/Classes/AutoRecorder.uc
@@ -50,7 +50,8 @@ function NotifyLevelChange()
     bIsPlaying = (Udemo.DemReader.DemoActive(GetPlayerOwner().XLevel) > 0);
 
     // Where else would you get the playername eh?
-    GetPlayerOwner().PlayerReplicationInfo.PlayerName = GetPlayerOwner().GetDefaultURL("name");
+    if (GetPlayerOwner().PlayerReplicationInfo != None)
+	    GetPlayerOwner().PlayerReplicationInfo.PlayerName = GetPlayerOwner().GetDefaultURL("name");
 
     // Check if we have to start the demorec!
     // (Anth) Added option to prevent recording when spectating


### PR DESCRIPTION
```
ScriptWarning: AutoRecorder Transient.AutoRecorder0 (Function udemo.AutoRecorder.NotifyLevelChange:0043) Accessed None 'PlayerReplicationInfo'
ScriptWarning: AutoRecorder Transient.AutoRecorder0 (Function udemo.AutoRecorder.NotifyLevelChange:004B) Attempt to assign variable through None
```
Fix OldUnreal/UnrealTournamentPatches/issues/314