### PR TITLE
Fix access none in DemoPlaybackSpec.PostRender

### DIFF
--- a/Classes/DemoPlaybackSpec.uc
+++ b/Classes/DemoPlaybackSpec.uc
@@ -1083,7 +1083,8 @@ event PostRender( canvas Canvas )
         if (Scoring == None && ScoringType != None)
         {
             Scoring = Spawn(ScoringType,PlayerLinked);
-            Scoring.OwnerHUD = myHUD;
+	    if (Scoring != None)
+            	Scoring.OwnerHUD = myHUD;
         }
 
         PlayerLinked.bShowScores=bShowScores;


### PR DESCRIPTION
```
ScriptWarning: DemoPlaybackSpec CTF-Command.DemoPlaybackSpec0 (Function udemo.DemoPlaybackSpec.PostRender:00DF) Accessed None 'Scoring'
ScriptWarning: DemoPlaybackSpec CTF-Command.DemoPlaybackSpec0 (Function udemo.DemoPlaybackSpec.PostRender:00E7) Attempt to assign variable through None
```