### PR TITLE
Make newSpeed at least 0.000001 in DemoInterface.SetSpeed

### DIFF
--- a/src/DemoInterface.cpp
+++ b/src/DemoInterface.cpp
@@ -426,6 +426,7 @@ void UDemoInterface::execSetSpeed (FFrame& Stack, RESULT_DECL)
 	guard (UDemoInterface::execSetSpeed);
 	P_GET_FLOAT(newSpeed);
 	P_FINISH;
+	newSpeed = Max(newSpeed, 0.000001f);
 	mySpeed = newSpeed;
 	if (PlayBackMode != 2) //not in timebased!
 		DemoSpec->Level->TimeDilation=newSpeed*(DemoDriver->RealDilation); //ratios own!


### PR DESCRIPTION
This must resolve some issues when to slomo passed 0 (can be invalid number, comma instead of dot, if used numpad for type and wrong kbd layout) or negative values. I think 0.000001 very good low bound. We have pause for anything lower 0.001 in fact.