### PR TITLE
Allow start autorecord on first load menu, even if UT started with server URL

### DIFF
--- a/Classes/AutoRecorder.uc
+++ b/Classes/AutoRecorder.uc
@@ -29,7 +29,7 @@ function NotifyBeforeLevelChange()
     if (Hack==none)
         Hack=GetEntryLevel().Spawn(class'OldSkoolHack');
     Hack.Rec=self;
-    Hack.OldLevel=string(GetLevel());
+    Hack.OldLevel=string(GetEntryLevel());
 
     // We don't want to record a levelchange o_O
     GetPlayerOwner().ConsoleCommand("stopdemo");

--- a/Classes/AutoRecorder.uc
+++ b/Classes/AutoRecorder.uc
@@ -23,6 +23,25 @@ function NotifyBeforeLevelChange()
 {
     Super.NotifyBeforeLevelChange();
 
+	LoadHack();
+}
+
+// =============================================================================
+// NotifyAfterLevelChange ~ Called after the actual levelchange and during first menu load
+// =============================================================================
+function NotifyAfterLevelChange()
+{
+    Super.NotifyAfterLevelChange();
+
+	if (Hack == None)
+		LoadHack();
+}
+
+// =============================================================================
+// LoadHack ~ Make actual load hack and setup it
+// =============================================================================
+function LoadHack()
+{
     // Hack == none
     // --> hack hasn't been spawned before!
     // --> spawn the hack into the entrylevel.


### PR DESCRIPTION
Related to #45
