### PR TITLE
Use current time if failed get time in udnative.execgetdemo

### DIFF
--- a/src/udnative.cpp
+++ b/src/udnative.cpp
@@ -155,7 +155,7 @@ void Uudnative::execgetdemo (FFrame& Stack, RESULT_DECL)
 		SQWORD FileTime = GFileManager->GetGlobalTime(*Filename);
 		FString FileDate;
 		
-		time_t ltime = FileTime;
+		time_t ltime = FileTime != ~0 ? FileTime : time(NULL);
 		char DateTime[100] = {0};
 		struct tm *tmp;
 		tmp = localtime(&ltime);


### PR DESCRIPTION
Such usually happen when this demo currently recorded.
Time will update on next open demo manager.
If demo released (recording done), then it load proper time instead.