### PR TITLE
Fix flood in log for Accessed None 'Game' in Engine.Inventory.Pickup.ValidTouch:0059 from NullAmmo

### DIFF
--- a/Classes/DemoPlaybackSpec.uc
+++ b/Classes/DemoPlaybackSpec.uc
@@ -1344,6 +1344,11 @@ function InitPlayerReplicationInfo()
 	PlayerReplicationInfo.PlayerName=GetDefaultURL("Name");
 	DummyAmmo=spawn(class'NullAmmo',self);
 	DummyAmmo.AmmoAmount=0;
+	DummyAmmo.BecomeItem();
+	DummyAmmo.GotoState('');
+	// pretend be replicated client item
+	DummyAmmo.Role = DummyAmmo.RemoteRole;
+	DummyAmmo.RemoteRole = ROLE_Authority;
 }
 
 //accessed none's suck:


### PR DESCRIPTION
```
ScriptWarning: NullAmmo CTF-XV-GooYou-MiAv1.NullAmmo0 (Function Engine.Inventory.Pickup.ValidTouch:0059) Accessed None 'Game'
ScriptWarning: NullAmmo CTF-XV-GooYou-MiAv1.NullAmmo0 (Function Engine.Inventory.Pickup.ValidTouch:0059) Accessed None 'Game'
ScriptWarning: NullAmmo CTF-XV-GooYou-MiAv1.NullAmmo0 (Function Engine.Inventory.Pickup.ValidTouch:0059) Accessed None 'Game'
ScriptWarning: NullAmmo CTF-XV-GooYou-MiAv1.NullAmmo0 (Function Engine.Inventory.Pickup.ValidTouch:0059) Accessed None 'Game'
ScriptWarning: NullAmmo CTF-XV-GooYou-MiAv1.NullAmmo0 (Function Engine.Inventory.Pickup.ValidTouch:0059) Accessed None 'Game'
```