### PR TITLE
Fix Accessed None 'OptionalObject' on return flag.

### DIFF
--- a/Classes/DemoPlaybackSpec.uc
+++ b/Classes/DemoPlaybackSpec.uc
@@ -1575,10 +1575,17 @@ function FlagPickup(PlayerReplicationInfo PRI, Object OptionalObject)
 
 function FlagReturn(Object OptionalObject)
 {
-	local int i;
+	local int i, FlagTeam;
+	
+	if (CTFFlag(OptionalObject) != None)
+		FlagTeam = CTFFlag(OptionalObject).Team;
+	else if (TeamInfo(OptionalObject) != None)
+		FlagTeam = TeamInfo(OptionalObject).TeamIndex;
+	else
+		return; // passed unknown object or None - ignore
 
 	for (i = 0; i < ArrayCount(FI); i++)
-		if (FI[i].HasFlag != None && FI[i].HasFlag.Team == TeamInfo(OptionalObject).TeamIndex)
+		if (FI[i].HasFlag != None && FI[i].HasFlag.Team == FlagTeam)
 		{
 			FI[i].HasFlag = None;
 			return;


### PR DESCRIPTION
`ScriptWarning: DemoPlaybackSpec CTF-XV-GooYou-MiAv1.DemoPlaybackSpec0 (Function udemo.DemoPlaybackSpec.FlagReturn:0053) Accessed None 'OptionalObject'`
OptionalObject on return flag with switch == 1 is CTFFlag, not TeamInfo.
